### PR TITLE
#162336816 Fetch one red flag record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # iReporter API
 
-[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-get-redflag-records-162336804)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-get-redflag-records-162336804)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-get-redflag-records-162336804)
+[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-get-one-redflag-162336816)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-get-one-redflag-162336816)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-get-one-redflag-162336816)
 
 This repository consists of implementation of the API endpoints for the [iReporter web application](https://khwilo.github.io/iReporter/UI/).  

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -7,3 +7,4 @@ api_blueprint = Blueprint("api", __name__)
 api = Api(api_blueprint)
 
 api.add_resource(RedFlagList, '/red-flags')
+api.add_resource(RedFlag, '/red-flags/<id>')

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -41,3 +41,16 @@ class RedFlagList(Resource):
             "data": incidences
         }, 200
     
+class RedFlag(Resource):
+    """Allows a request on a single RedFlag item"""
+    def get(self, id):
+        if id.isdigit():
+            incidence = IncidenceModel.get_incidence_by_id(int(id))
+            if incidence == {}:
+                return {'message': "red flag with id {} doesn't exist".format(id)}, 404
+            return {
+                "status": 200,
+                "data": [incidence]
+            }
+        else:
+            return {'message': "red-flag id must be an Integer"}, 400

--- a/tests.py
+++ b/tests.py
@@ -36,6 +36,15 @@ class IncidenceTestCase(unittest.TestCase):
         self.assertEqual(200, response_msg["status"])
         self.assertEqual(IncidenceModel.get_all_incidences(), response_msg["data"])
 
+    def test_fetching_one_red_flag(self):
+        """Test whether the API can fetch one red flag"""
+        res = self.client().post('/red-flags', data=self.incidences)
+        self.assertEqual(res.status_code, 201)
+        res = self.client().get('/red-flags/1')
+        self.assertEqual(res.status_code, 200)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(200, response_msg["status"])
+        self.assertEqual(IncidenceModel.get_incidence_by_id(1), response_msg["data"][0])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What does this PR do?
Adds the functionality to fetch one red flag record

#### Description of Task to be completed?
- Add tests to get a specific red flag
- Implement a method to fetch one red flag record
- Have the API endpoint `GET /red-flags/<red-flag-id>` working

#### How should this be manually tested?
On Postman, test the above endpoint.

#### What are the relevant pivotal tracker stories?
#162336816