### PR TITLE
#162341719 Delete one red flag record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # iReporter API
 
-[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-get-one-redflag-162336816)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-get-one-redflag-162336816)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-get-one-redflag-162336816)
+[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-delete-one-redflag-162341719)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-delete-one-redflag-162341719)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-delete-one-redflag-162341719)
 
 This repository consists of implementation of the API endpoints for the [iReporter web application](https://khwilo.github.io/iReporter/UI/).  

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -54,3 +54,21 @@ class RedFlag(Resource):
             }
         else:
             return {'message': "red-flag id must be an Integer"}, 400
+
+    def delete(self, id):
+        if id.isdigit():
+            incidence = IncidenceModel.get_incidence_by_id(int(id))
+            if incidence == {}:
+                return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+            else:
+                IncidenceModel.delete_by_id(int(id))
+                return {
+                    "status": 200,
+                    "data": [{
+                        "id": int(id),
+                        "message": "red-flag record has been deleted"
+                    }]
+                }, 200
+        else:
+            return {'message': "incidence id must be an Integer"}, 400
+            

--- a/tests.py
+++ b/tests.py
@@ -46,5 +46,20 @@ class IncidenceTestCase(unittest.TestCase):
         self.assertEqual(200, response_msg["status"])
         self.assertEqual(IncidenceModel.get_incidence_by_id(1), response_msg["data"][0])
 
+    def test_delete_one_red_flag(self):
+        """Test whether the API can delete a red flag"""
+        res = self.client().post('/red-flags', data=self.incidences)
+        self.assertEqual(res.status_code, 201)
+        res = self.client().delete('/red-flags/1')
+        self.assertEqual(res.status_code, 200)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("red-flag record has been deleted", response_msg["data"][0]["message"])
+        res = self.client().get('/red-flags/1')
+        self.assertEqual(res.status_code, 404)
+        res = self.client().delete('/red-flags/2') # Test deletion of non-existent red flag record
+        self.assertEqual(res.status_code, 404)
+        res = self.client().delete('/red-flags/a')
+        self.assertEqual(res.status_code, 400) # Test that only integer ids are allowed
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What does this PR do?
Add the functionality to delete one specific red flag by its id

#### Description of Task to be completed?
- Add tests for deleting one red flag record
- Implement the logic for deleting one red flag record
- Have the API endpoint `DELETE /red-flags/<red-flag-id>` working

#### How should this be manually tested?
On Postman, test the above endpoint.

#### What are the relevant pivotal tracker stories?
#162341719
