### PR TITLE
#162344009 Fix delete red flag implementation build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # iReporter API
 
-[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-get-one-redflag-162336816)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-get-one-redflag-162336816)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-get-one-redflag-162336816)
+[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=bg-delete-build-failed-162344009)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=bg-delete-build-failed-162344009)](https://coveralls.io/github/khwilo/ireporter-API?branch=bg-delete-build-failed-162344009)
 
 This repository consists of implementation of the API endpoints for the [iReporter web application](https://khwilo.github.io/iReporter/UI/).  

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -54,3 +54,20 @@ class RedFlag(Resource):
             }
         else:
             return {'message': "red-flag id must be an Integer"}, 400
+
+    def delete(self, id):
+        if id.isdigit():
+            incidence = IncidenceModel.get_incidence_by_id(int(id))
+            if incidence == {}:
+                return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+            else:
+                IncidenceModel.delete_by_id(int(id))
+                return {
+                    "status": 200,
+                    "data": [{
+                        "id": int(id),
+                        "message": "red-flag record has been deleted"
+                    }]
+                }, 200
+        else:
+            return {'message': "incidence id must be an Integer"}, 400


### PR DESCRIPTION
#### What does this PR do?
Fixes the HTTP status code 405 when building the delete red flag implementation

#### Description of Task to be completed?
- Add method to delete a red flag record
- Have the API endpoint `DELETE /red-flags/<id>` working

#### How should this be manually tested?
On Postman, test the above endpoint.

#### What are the relevant pivotal tracker stories?
#162344009
