### PR TITLE
#162348979 Allow only integer values for red flag ids 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # iReporter API
 
-[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-edit-redflag-comment-162336846)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-edit-redflag-comment-162336846)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-edit-redflag-comment-162336846)  
-
-** REBUILD LOCATION IMPLEMENTATION**
+[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-allow-integer-ids-162348979)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-allow-integer-ids-162348979)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-allow-integer-ids-162348979)  
 
 This repository consists of implementation of the API endpoints for the [iReporter web application](https://khwilo.github.io/iReporter/UI/).  

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -93,7 +93,7 @@ class RedFlagLocation(Resource):
                         "message": "Updated red-flag record’s location"
                     }]
                 }
-        return {'message': "incidence id must be an Integer"}, 400
+        return {'message': "red-flag id must be an Integer"}, 400
         
 class RedFlagComment(Resource):
     """Allows a request on a single RedFlag comment"""
@@ -116,5 +116,5 @@ class RedFlagComment(Resource):
                     }]
                 }
         else:
-            return {'message': "incidence id must be an Integer"}, 400
+            return {'message': "red-flag id must be an Integer"}, 400
     

--- a/tests.py
+++ b/tests.py
@@ -45,6 +45,10 @@ class IncidenceTestCase(unittest.TestCase):
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(200, response_msg["status"])
         self.assertEqual(IncidenceModel.get_incidence_by_id(1), response_msg["data"][0])
+        res = self.client().get('/red-flags/1-')
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("red-flag id must be an Integer", response_msg["message"])
+        self.assertEqual(res.status_code, 400)
 
     def test_delete_one_red_flag(self):
         """Test whether the API can delete a red flag"""
@@ -77,6 +81,15 @@ class IncidenceTestCase(unittest.TestCase):
         res = self.client().get('/red-flags/1')
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual("5S10E", response_msg["data"][0]["location"])
+        res = self.client().put(
+            '/red-flags/1a/location',
+            data = {
+                "location": "5S10E"
+            }
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("red-flag id must be an Integer", response_msg["message"])
+        self.assertEqual(res.status_code, 400)
 
     def test_edit_red_flag_comment(self):
         """Test whether the API can edit a red flag location"""
@@ -94,6 +107,15 @@ class IncidenceTestCase(unittest.TestCase):
         res = self.client().get('/red-flags/1')
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual("RED FLAG TEST TWO", response_msg["data"][0]["comment"])
+        res = self.client().put(
+            '/red-flags/x/comment',
+            data = {
+                "comment": "Error in comment"
+            }
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("red-flag id must be an Integer", response_msg["message"])
+        self.assertEqual(res.status_code, 400)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What does this PR do?
Restrict a red flag ID to be an integer value

#### Description of Task to be completed?
Have the follwoing endpoints working:
`GET /red-flags/<red-flag-id>`
`PUT /red-flags/<red-flag-id>/location`
`PUT /red-flags/<red-flag-id>/comment`
`PUT /red-flags/<red-flag-id>/status`
`DEL /red-flags/<red-flag-id>`

#### How should this be manually tested?
On Postman, test the above endpoints working. For the *PUT* use the following header:
*key* - **Content-Type** , *value* - **application/json**

#### What are the relevant pivotal tracker stories?
#162348979