### PR TITLE
#162376841 Hash a user's password

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iReporter API
 
-[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ch-api-endpoints-description-162361783)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ch-api-endpoints-description-162361783)](https://coveralls.io/github/khwilo/ireporter-API?branch=ch-api-endpoints-description-162361783)  
+[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-hash-user-password-162376841)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-hash-user-password-162376841)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-hash-user-password-162376841)  
 
 This repository consists of implementation of the API endpoints for the [iReporter web application](https://khwilo.github.io/iReporter/UI/).  
 

--- a/app/api/v1/models/user.py
+++ b/app/api/v1/models/user.py
@@ -1,5 +1,6 @@
 '''This module represents a User entity'''
 from datetime import datetime
+from passlib.hash import pbkdf2_sha256 as sha256
 
 USERS = []
 
@@ -20,6 +21,14 @@ class UserModel:
     def get_user_id(self):
         '''Returns the id of the user'''
         return self.id
+
+    @staticmethod
+    def generate_password_hash(password):
+        return sha256.hash(password)
+
+    @staticmethod
+    def verify_password_hash(password, _hash):
+        return sha256.verify(password, _hash)
 
     @staticmethod
     def add_a_user(user):

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -143,7 +143,7 @@ class UserRegistration(Resource):
             phoneNumber = data['phoneNumber'],
             username = data['username'],
             isAdmin = data['isAdmin'],
-            password = data['password']
+            password = UserModel.generate_password_hash(data['password'])
         )
 
         username = data['username']
@@ -189,7 +189,7 @@ class UserLogin(Resource):
         if not current_user:
             return {'message': "User with username '{}' doesn't exist!".format(data['username'])}, 400
 
-        if data['password'] == current_user['password']:
+        if UserModel.verify_password_hash(data['password'], current_user['password']):
             return {
                 'message': 'Logged in as {}'.format(current_user['username']),
             }, 200

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Jinja2==2.10
 MarkupSafe==1.1.0
 more-itertools==4.3.0
 nose2==0.8.0
+passlib==1.7.1
 pathlib2==2.3.3
 pluggy==0.8.0
 py==1.7.0

--- a/tests.py
+++ b/tests.py
@@ -140,6 +140,12 @@ class UserTestCase(unittest.TestCase):
             "username": "jondo",
             "password": "12345"
         }
+
+        # Provide a user with a wrong password
+        self.wrong_user_password = {
+            "username": "jondo",
+            "password": "wrong_password"
+        }
     
     def test_user_regisration(self):
         """Test whether the API can register a user"""
@@ -158,6 +164,10 @@ class UserTestCase(unittest.TestCase):
         res = self.client().post('/api/v1/login', data=self.registered_user)
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual("Logged in as jondo", response_msg["message"])
+        res = self.client().post('/api/v1/register', data=self.new_user)
+        res = self.client().post('/api/v1/login', data=self.wrong_user_password)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("Wrong credentials", response_msg["message"])
 
     def tearDown(self):
         del USERS[:]


### PR DESCRIPTION
#### What does this PR do?
Prevent storage of users passwords as plain texts by hashing them.

#### Description of Task to be completed?
- Write tests to check if the password entered by the user matches the one stored in the dictionary.
- Use the Python **passlib** package to generate a password hash.
- Verify the hashed password with the password entered by the user.

#### How should this be manually tested?
On Postman, test the endpoint ***POST  'api/v1/login'***  with the following header:

*key* - **Content-Type** , *value* - **application/json**

#### What are the relevant pivotal tracker stories?
#162376841