### PR TITLE
#162457254 Allow an administrator to change a red flag status 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iReporter API
 
-[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=develop)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=develop&kill_cache=1)](https://coveralls.io/github/khwilo/ireporter-API?branch=develop&kill_cache=1)  
+[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-change-intervention-status-162457254)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-change-intervention-status-162457254&kill_cache=1)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-change-intervention-status-162457254&kill_cache=1)  
 
 This repository consists of implementation of the API endpoints for the [iReporter web application](https://khwilo.github.io/iReporter/UI/).  
 
@@ -13,4 +13,4 @@ This repository consists of implementation of the API endpoints for the [iReport
 - `PUT '/api/v1/red-flags/<red-flag-id>/location'` - Edit the location of a specific red-flag record.
 - `PUT '/api/v1/red-flags/<red-flag-id>/comment'` - Edit the comment of a specific red-flag record.
 - `POST '/auth/register'` - Create a user record.
-- `POST '/auth/login` - Log in a user.  
+- `POST '/auth/login'` - Log in a user.  

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -12,6 +12,7 @@ api.add_resource(RedFlagList, '/red-flags')
 api.add_resource(RedFlag, '/red-flags/<id>')
 api.add_resource(RedFlagLocation, '/red-flags/<id>/location')
 api.add_resource(RedFlagComment, '/red-flags/<id>/comment')
+api.add_resource(RedFlagStatus, '/red-flags/<id>/status')
 
 auth_api.add_resource(UserRegistration, '/register')
 auth_api.add_resource(UserLogin, '/login')

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -136,7 +136,7 @@ class RedFlagStatus(Resource):
     @jwt_required
     def put(self, id):
         parser = reqparse.RequestParser()
-        parser.add_argument("status", type=str, required=True, help='Status cannot be blank')
+        parser.add_argument('status', type=str, required=True, help='Status cannot be blank!')
         data = parser.parse_args()
 
         current_user = get_jwt_identity()
@@ -144,7 +144,7 @@ class RedFlagStatus(Resource):
 
         if user['isAdmin']:
             if id.isdigit():
-                incidence = IncidenceModel.get_incidence_by_id(int)
+                incidence = IncidenceModel.get_incidence_by_id(int(id))
                 if incidence == {}:
                     return {'message': "red flag with id {} doesn't exit".format(id)}, 404
                 else:

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -131,6 +131,37 @@ class RedFlagComment(Resource):
         else:
             return {'message': "red-flag id must be an Integer"}, 400
 
+class RedFlagStatus(Resource):
+    """Change the status of a red flag"""
+    @jwt_required
+    def put(self, id):
+        parser = reqparse.RequestParser()
+        parser.add_argument("status", type=str, required=True, help='Status cannot be blank')
+        data = parser.parse_args()
+
+        current_user = get_jwt_identity()
+        user = UserModel.get_user_by_username(current_user)
+
+        if user['isAdmin']:
+            if id.isdigit():
+                incidence = IncidenceModel.get_incidence_by_id(int)
+                if incidence == {}:
+                    return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+                else:
+                    incidence.update(data)
+                    return {
+                        "status": 200,
+                        "data": [
+                            {
+                                "id": id,
+                                "message": "Updated red-flag record's status"
+                            }
+                        ]
+                    }
+            else:
+                return {'message': "incidence id must be an Integer"}, 400
+        return {'message': 'Only administrators can change the status!'}, 404
+
 # USER MODEL #
 class UserRegistration(Resource):
     """Registers a new user"""

--- a/tests.py
+++ b/tests.py
@@ -310,6 +310,19 @@ class IncidenceTestCase(unittest.TestCase):
         res = self.client().get('/api/v1/red-flags/1', headers=self.get_authentication_headers(access_token))
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual("RED FLAG COMMENT UPDATE", response_msg["data"][0]["comment"])
+
+    def test_unauthorized_edit_of_a_red_flag_status(self):
+        """Test the API doesn't allow an unauthorized edit of a red flag"""
+        res = self.client().put(
+            '/api/v1/red-flags/1/status', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(
+                {
+                    "status": "UNRESOLVED"
+                }
+            )
+        )
+        self.assertEqual(res.status_code, 401)
     
     def test_non_integer_id_not_allowed(self):
         """Test the API doesn't allow non integer values"""

--- a/tests.py
+++ b/tests.py
@@ -323,6 +323,66 @@ class IncidenceTestCase(unittest.TestCase):
             )
         )
         self.assertEqual(res.status_code, 401)
+
+    def test_edit_red_flag_status(self):
+        """Test the API can edit a red flag status"""
+        # Regular user registration
+        res = self.client().post('/auth/register', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.regular_user)
+        )
+        self.assertEqual(res.status_code, 201)
+
+        # Regular user login
+        res = self.client().post('/auth/login', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.regular_user_login)
+        )
+        self.assertEqual(res.status_code, 200)
+
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg['access_token'] # Get access token for the regular user to create a red flag
+
+        # Regular user creates a post 
+        res = self.client().post("/api/v1/red-flags", 
+            headers=self.get_authentication_headers(access_token), 
+            data=json.dumps(self.incidences))
+        self.assertEqual(res.status_code, 201)
+
+        # Administrator registration
+        res = self.client().post('/auth/register', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.admin_user)
+        )
+        self.assertEqual(res.status_code, 201)
+
+         # Administrator login
+        res = self.client().post('/auth/login', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.admin_user_login)
+        )
+        self.assertEqual(res.status_code, 200)
+
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg['access_token'] # Adminstrator's access token
+
+        # Adminstrator changes the red flag status
+        res = self.client().put(
+            "/api/v1/red-flags/1/status", 
+            headers=self.get_authentication_headers(access_token), 
+            data=json.dumps(
+                {
+                    "status": "RESOLVED"
+                }
+            )
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 200)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("Updated red-flag record's status", response_msg["data"][0]["message"])
+        res = self.client().get('/api/v1/red-flags/1', headers=self.get_authentication_headers(access_token))
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("RESOLVED", response_msg["data"][0]["status"])
     
     def test_non_integer_id_not_allowed(self):
         """Test the API doesn't allow non integer values"""
@@ -373,6 +433,27 @@ class IncidenceTestCase(unittest.TestCase):
         self.assertEqual("red-flag id must be an Integer", response_msg["message"])
         self.assertEqual(res.status_code, 400)
 
+        res = self.client().post('/auth/register', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.admin_user))
+        self.assertEqual(res.status_code, 201)
+        res = self.client().post('/auth/login', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.admin_user_login))
+        self.assertEqual(res.status_code, 200)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg['access_token']
+        res = self.client().put(
+            'api/v1/red-flags/e/status',
+            headers=self.get_authentication_headers(access_token), 
+            data=json.dumps(
+                {
+                    "status": "REJECTED"
+                }
+            )
+        )
+        self.assertEqual(res.status_code, 400) 
+
     def test_an_empty_list_cannot_be_modified(self):
         """Test that the API cannot allow empty lists to be modified"""
         res = self.client().post('/auth/register', 
@@ -409,6 +490,27 @@ class IncidenceTestCase(unittest.TestCase):
             data=json.dumps(
                 {
                     "comment": "RED FLAG COMMENT UPDATE"
+                }
+            )
+        )
+        self.assertEqual(res.status_code, 404)
+
+        res = self.client().post('/auth/register', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.admin_user))
+        self.assertEqual(res.status_code, 201)
+        res = self.client().post('/auth/login', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.admin_user_login))
+        self.assertEqual(res.status_code, 200)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg['access_token']
+        res = self.client().put(
+            'api/v1/red-flags/5/status',
+            headers=self.get_authentication_headers(access_token), 
+            data=json.dumps(
+                {
+                    "status": "UNDER INVESTIGATION"
                 }
             )
         )


### PR DESCRIPTION
#### What does this PR do?
Changes the status of a red flag from draft to under investigation, resolved or rejected

#### Description of Task to be completed?
- Write tests for editing a red flag status
- Implement the logic for an administrator to change a red flag status

#### How should this be manually tested?
On Postman test the endpoints:
- `PUT '/api/v1/red-flags/<red-flag-id>/status'`

with the following headers:
- *key*  -  **Content-Type** , *value* - **application/json**
- *key*  -  **Authorization**, *value* - **Bearer <access_token>**

**NB** - *The access token value is retrieved from the response message after login in*

#### What are the relevant pivotal tracker stories?
#162457254