### PR TITLE
#162499170 Allow only regular users to modify a red flag comment or location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iReporter API
 
-[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-change-intervention-status-162457254)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-change-intervention-status-162457254&kill_cache=1)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-change-intervention-status-162457254&kill_cache=1)  
+[![Build Status](https://travis-ci.org/khwilo/ireporter-API.svg?branch=ft-regular-user-modify-162499170)](https://travis-ci.org/khwilo/ireporter-API) [![Coverage Status](https://coveralls.io/repos/github/khwilo/ireporter-API/badge.svg?branch=ft-regular-user-modify-162499170)](https://coveralls.io/github/khwilo/ireporter-API?branch=ft-regular-user-modify-162499170)  
 
 This repository consists of implementation of the API endpoints for the [iReporter web application](https://khwilo.github.io/iReporter/UI/).  
 

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -114,7 +114,7 @@ class RedFlagLocation(Resource):
                         }]
                     }
             return {'message': "red-flag id must be an Integer"}, 400
-        return {'message': "Only regular users can delete a red flag"}, 401
+        return {'message': "Only regular users can edit a red flag's location"}, 401
         
 class RedFlagComment(Resource):
     """Allows a request on a single RedFlag comment"""
@@ -124,21 +124,26 @@ class RedFlagComment(Resource):
         parser.add_argument('comment', type=str, required=True, help='Comment cannot be blank!')
         data = parser.parse_args()
 
-        if id.isdigit():
-            incidence = IncidenceModel.get_incidence_by_id(int(id))
-            if incidence == {}:
-                return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+        current_user = get_jwt_identity()
+        user = UserModel.get_user_by_username(current_user)
+
+        if not user['isAdmin']:
+            if id.isdigit():
+                incidence = IncidenceModel.get_incidence_by_id(int(id))
+                if incidence == {}:
+                    return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+                else:
+                    incidence.update(data)
+                    return {
+                        "status": 200,
+                        "data": [{
+                            "id": id,
+                            "message": "Updated red-flag record’s comment"
+                        }]
+                    }
             else:
-                incidence.update(data)
-                return {
-                    "status": 200,
-                    "data": [{
-                        "id": id,
-                        "message": "Updated red-flag record’s comment"
-                    }]
-                }
-        else:
-            return {'message': "red-flag id must be an Integer"}, 400
+                return {'message': "red-flag id must be an Integer"}, 400
+        return {'message': "Only regular users can edit a red flag's comment"}, 401
 
 class RedFlagStatus(Resource):
     """Change the status of a red flag"""

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -67,21 +67,26 @@ class RedFlag(Resource):
 
     @jwt_required
     def delete(self, id):
-        if id.isdigit():
-            incidence = IncidenceModel.get_incidence_by_id(int(id))
-            if incidence == {}:
-                return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+        current_user  = get_jwt_identity()
+        user = UserModel.get_user_by_username(current_user)
+        
+        if not user['isAdmin']:
+            if id.isdigit():
+                incidence = IncidenceModel.get_incidence_by_id(int(id))
+                if incidence == {}:
+                    return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+                else:
+                    IncidenceModel.delete_by_id(int(id))
+                    return {
+                        "status": 200,
+                        "data": [{
+                            "id": int(id),
+                            "message": "red-flag record has been deleted"
+                        }]
+                    }, 200
             else:
-                IncidenceModel.delete_by_id(int(id))
-                return {
-                    "status": 200,
-                    "data": [{
-                        "id": int(id),
-                        "message": "red-flag record has been deleted"
-                    }]
-                }, 200
-        else:
-            return {'message': "incidence id must be an Integer"}, 400
+                return {'message': "incidence id must be an Integer"}, 400
+        return {'message': 'Only regular users can delete a red flag'}, 401
 
 class RedFlagLocation(Resource):
     """Allows a request on a single RedFlag Location"""

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -96,21 +96,25 @@ class RedFlagLocation(Resource):
         parser.add_argument('location', type=str, required=True, help='Location cannot be blank!')
         data = parser.parse_args()
 
-    
-        if id.isdigit():
-            incidence = IncidenceModel.get_incidence_by_id(int(id))
-            if incidence == {}:
-                return {'message': "red flag with id {} doesn't exit".format(id)}, 404
-            else:
-                incidence.update(data)
-                return {
-                    "status": 200,
-                    "data": [{
-                        "id": id,
-                        "message": "Updated red-flag record’s location"
-                    }]
-                }
-        return {'message': "red-flag id must be an Integer"}, 400
+        current_user = get_jwt_identity()
+        user = UserModel.get_user_by_username(current_user)
+
+        if not user['isAdmin']:    
+            if id.isdigit():
+                incidence = IncidenceModel.get_incidence_by_id(int(id))
+                if incidence == {}:
+                    return {'message': "red flag with id {} doesn't exit".format(id)}, 404
+                else:
+                    incidence.update(data)
+                    return {
+                        "status": 200,
+                        "data": [{
+                            "id": id,
+                            "message": "Updated red-flag record’s location"
+                        }]
+                    }
+            return {'message': "red-flag id must be an Integer"}, 400
+        return {'message': "Only regular users can delete a red flag"}, 401
         
 class RedFlagComment(Resource):
     """Allows a request on a single RedFlag comment"""

--- a/tests.py
+++ b/tests.py
@@ -233,7 +233,7 @@ class IncidenceTestCase(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 401)
 
-    def test_admin_edit_red_flag(self):
+    def test_admin_edit_red_flag_location(self):
         """Test the API cannot edit a red flag location when the user is an administrator"""
         res = self.client().post('/auth/register', 
             headers=self.get_accept_content_type_headers(), 
@@ -273,7 +273,7 @@ class IncidenceTestCase(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 401)
         response_msg = json.loads(res.data.decode("UTF-8"))
-        self.assertEqual("Only regular users can delete a red flag", response_msg["message"])
+        self.assertEqual("Only regular users can edit a red flag's location", response_msg["message"])
 
     
     def test_edit_red_flag_location(self):
@@ -325,7 +325,48 @@ class IncidenceTestCase(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 401)
 
-    
+    def test_admin_edit_red_flag_comment(self):
+        """Test the API cannot edit a red flag comment when the user is an administrator"""
+        res = self.client().post('/auth/register', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.regular_user))
+        self.assertEqual(res.status_code, 201)
+        res = self.client().post('/auth/login', 
+            headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.regular_user_login))
+        self.assertEqual(res.status_code, 200)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg['access_token']
+        res = self.client().post('/api/v1/red-flags', 
+            headers=self.get_authentication_headers(access_token), 
+            data=json.dumps(self.incidences)) # Create a red-flag
+        self.assertEqual(res.status_code, 201)
+
+        # Administrator registration
+        res = self.client().post('/auth/register', headers=self.get_accept_content_type_headers(), 
+            data=json.dumps(self.admin_user))
+        self.assertEqual(res.status_code, 201)
+        
+        # Administrator login
+        res = self.client().post('/auth/login', headers=self.get_accept_content_type_headers(),
+            data=json.dumps(self.admin_user_login))
+        self.assertEqual(res.status_code, 200)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg['access_token']
+
+        res = self.client().put(
+            '/api/v1/red-flags/1/comment', 
+            headers=self.get_authentication_headers(access_token), 
+            data=json.dumps(
+                {
+                    "comment": "UNRESOLVED"
+                }
+            )
+        )
+        self.assertEqual(res.status_code, 401)
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual("Only regular users can edit a red flag's comment", response_msg["message"])
+
     def test_edit_red_flag_comment(self):
         """Test whether the API can edit a red flag comment"""
         res = self.client().post('/auth/register', 


### PR DESCRIPTION
#### What does this PR do?
Make it possible for only regular users to modify a red flag's comment or location

#### Description of Task to be completed?
- Implement logic and tests to allow only regular users to modify a red flag

#### How should this be manually tested?
On Postman test the endpoints:
- `PUT '/api/v1/red-flags/<red-flag-id>/location'`
- `PUT '/api/v1/red-flags/<red-flag-id>/comment'`

with the following headers:
- *key*  -  **Content-Type** , *value* - **application/json**
- *key*  -  **Authorization**, *value* - **Bearer <access_token>**

**NB** - *The access token value is retrieved from the response message after login in*

#### What are the relevant pivotal tracker stories?
#162499170